### PR TITLE
Fix charge endpoint for custom example

### DIFF
--- a/web.rb
+++ b/web.rb
@@ -18,7 +18,7 @@ end
 post '/charge' do
   authenticate!
   # Get the credit card details submitted by the form
-  source = params[:source] || params[:stripe_token] || params[:stripeToken]
+  source = params[:source]
 
   # Create the charge on Stripe's servers - this will charge the user's card
   begin
@@ -96,4 +96,26 @@ def authenticate!
     session[:customer_id] = @customer.id
   end
   @customer
+end
+
+# This endpoint is used by the Obj-C example to complete a charge.
+post '/charge_card' do
+  # Get the credit card details submitted by the form
+  token = params[:stripe_token]
+
+  # Create the charge on Stripe's servers - this will charge the user's card
+  begin
+    charge = Stripe::Charge.create(
+      :amount => params[:amount], # this number should be in cents
+      :currency => "usd",
+      :card => token,
+      :description => "Example Charge"
+    )
+  rescue Stripe::StripeError => e
+    status 402
+    return "Error creating charge: #{e.message}"
+  end
+
+  status 200
+  return "Charge successfully created"
 end


### PR DESCRIPTION
r? @jflinter 

A user pointed out that completing a charge doesn't work in the "Custom" example app [0]. I've fixed this, and tested charging in both example apps.

[0] https://github.com/stripe/stripe-ios/issues/461