### PR TITLE
Add customer parameter to webhook charge creation

### DIFF
--- a/web.rb
+++ b/web.rb
@@ -139,6 +139,7 @@ post '/stripe-webhook' do
         :amount => source.amount,
         :currency => source.currency,
         :source => source.id,
+        :customer => source.metadata["customer"],
         :description => "Example Charge"
       )
     rescue Stripe::StripeError => e


### PR DESCRIPTION
r? @bdorfman-stripe 

I've tested this against the example app to make sure it properly associates a customer with the charge if there's a customer ID in metadata, and also works if metadata is missing.

![screenshot 2017-04-27 15 40 22](https://cloud.githubusercontent.com/assets/23086960/25501298/3d7604a6-2b60-11e7-8e34-4aaa0e5a5d5c.png)


