### PR TITLE
Bump deps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
-ruby "2.1.2"
-gem 'sinatra', '1.4.5'
-gem 'stripe', '1.20.0'
+ruby "2.2.7"
+gem 'sinatra', '1.4.7'
+gem 'stripe', '1.58.0'
 gem 'dotenv', '1.0.2'
-gem 'json', '1.8.2'
+gem 'json', '1.8.6'
 gem 'encrypted_cookie', '0.0.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,26 +1,34 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    domain_name (0.5.20170404)
+      unf (>= 0.0.5, < 1.0.0)
     dotenv (1.0.2)
     encrypted_cookie (0.0.4)
-    json (1.8.2)
-    mime-types (2.4.3)
-    netrc (0.10.3)
-    rack (1.5.2)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
+    json (1.8.6)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
+    netrc (0.11.0)
+    rack (1.6.6)
     rack-protection (1.5.3)
       rack
-    rest-client (1.7.3)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
-    sinatra (1.4.5)
-      rack (~> 1.4)
+    rest-client (2.0.2)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
+    sinatra (1.4.7)
+      rack (~> 1.5)
       rack-protection (~> 1.4)
-      tilt (~> 1.3, >= 1.3.4)
-    stripe (1.20.0)
-      json (~> 1.8.1)
-      mime-types (>= 1.25, < 3.0)
-      rest-client (~> 1.4)
-    tilt (1.4.1)
+      tilt (>= 1.3, < 3)
+    stripe (1.58.0)
+      rest-client (>= 1.4, < 4.0)
+    tilt (2.0.7)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.4)
 
 PLATFORMS
   ruby
@@ -28,9 +36,12 @@ PLATFORMS
 DEPENDENCIES
   dotenv (= 1.0.2)
   encrypted_cookie (= 0.0.4)
-  json (= 1.8.2)
-  sinatra (= 1.4.5)
-  stripe (= 1.20.0)
+  json (= 1.8.6)
+  sinatra (= 1.4.7)
+  stripe (= 1.58.0)
+
+RUBY VERSION
+   ruby 2.2.7p470
 
 BUNDLED WITH
-   1.10.6
+   1.14.6


### PR DESCRIPTION
r? @bg-stripe 

Heroku no longer supports Ruby 2.1 (cf. [here](https://devcenter.heroku.com/articles/ruby-support#supported-runtimes)), so the app can no longer be deployed to Heroku.

This PR updates the Gemfile to use Ruby 2.2.7.

While I was at it, I also bumped minor versions of gems the project depends on.
