### PR TITLE
Allow endpoint to take specific customer

### DIFF
--- a/web.rb
+++ b/web.rb
@@ -35,13 +35,14 @@ post '/charge' do
   authenticate!
   # Get the credit card details submitted by the form
   source = params[:source]
-
+  customer = params[:customer_id] || @customer.id
+  
   # Create the charge on Stripe's servers - this will charge the user's card
   begin
     charge = Stripe::Charge.create(
       :amount => params[:amount], # this number should be in cents
       :currency => "usd",
-      :customer => @customer.id,
+      :customer => customer,
       :source => source,
       :description => "Example Charge",
       :shipping => params[:shipping],


### PR DESCRIPTION
Changes: Allow the endpoint to charge a specified customer from the client. (The source still has to match the customer we're trying to charge.)

Why: The session logic doesn't work on Android across activities out of the box. I suspect we could do something on the client to move the cookies around to make the session work but I think that would make for a more confusing demo.

Testing: Tested the iOS still makes charges and that the Android demo app when deployed to my example backend.

r? @bg-stripe @mrmcduff-stripe 
