### PR TITLE
Make shipping JSON work with android retrofit/gson

### DIFF
--- a/web.rb
+++ b/web.rb
@@ -36,7 +36,11 @@ post '/charge' do
   # Get the credit card details submitted by the form
   source = params[:source]
   customer = params[:customer_id] || @customer.id
-  
+  if params[:shipping].instance_of? String
+    shipping = JSON.parse(params[:shipping])
+  else
+    shipping = params[:shipping]
+  end
   # Create the charge on Stripe's servers - this will charge the user's card
   begin
     charge = Stripe::Charge.create(
@@ -45,7 +49,7 @@ post '/charge' do
       :customer => customer,
       :source => source,
       :description => "Example Charge",
-      :shipping => params[:shipping],
+      :shipping => shipping,
     )
   rescue Stripe::StripeError => e
     status 402


### PR DESCRIPTION
Make the endpoint play nice with Retrofit.

@mrmcduff-stripe my understanding of what's happening is a little shaky so please do check my statements but:

Our JSONs get escaped into Strings which the demo backend doesn't recognize as JSONs. 
see example ios response:
<img width="1147" alt="screen shot 2017-10-09 at 10 44 33 pm" src="https://user-images.githubusercontent.com/30061905/31371006-8b0200f2-ad43-11e7-8b83-dd96661d7120.png">

see example android response on server (note the escapes):
<img width="1155" alt="screen shot 2017-10-09 at 10 44 42 pm" src="https://user-images.githubusercontent.com/30061905/31371008-8f83997e-ad43-11e7-8b5b-ff50f37b1d41.png">

which the retrofit documentation indicates does happen:
https://github.com/square/retrofit/blob/master/retrofit/src/main/java/retrofit2/http/Field.java#L31

r? @mrmcduff-stripe 