### PR TITLE
Set Content-Type to 'application/json' for ephemeral_keys endpoint

### DIFF
--- a/web.rb
+++ b/web.rb
@@ -32,6 +32,7 @@ post '/ephemeral_keys' do
     return log_info("Error creating ephemeral key: #{e.message}")
   end
 
+  content_type :json
   status 200
   key.to_json
 end


### PR DESCRIPTION
Currently the endpoint returns JSON data but with a content-type of `text/html`. This can cause issues if the app is configured to check the Content-Type header when decoding the response.

Current behaviour : 

```
curl https://example-karlr-current.herokuapp.com/ephemeral_keys -d "api_version=2018-02-28" -v 2>&1 | grep "Content-Type"
> Content-Type: application/x-www-form-urlencoded
< Content-Type: text/html;charset=utf-8
```

With this PR:
```
curl https://example-karlr.herokuapp.com/ephemeral_keys -d "api_version=2018-02-28" -v 2>&1 | grep "Content-Type"
> Content-Type: application/x-www-form-urlencoded
< Content-Type: application/json
```