### PR TITLE
Use `Sinatra::IndifferentHash` instead of `indifferent_hash` due to Sinatra update

### DIFF
--- a/web.rb
+++ b/web.rb
@@ -42,7 +42,7 @@ post '/charge' do
   # Get the credit card details submitted
   payload = params
   if request.content_type.include? 'application/json' and params.empty?
-    payload = indifferent_params(JSON.parse(request.body.read))
+    payload = Sinatra::IndifferentHash[JSON.parse(request.body.read)]
   end
 
   source = payload[:source]


### PR DESCRIPTION
Bug introduced by #24, when we updated Sinatra from 1.4.7 -> 2.0.1, but missed updating
the json content-type branch.

Fixes #29, alternative to #30 (don't need to maintain `indifferent_hash` backwards compatibility because we specify the Sinatra version in the Gemfile)