### PR TITLE
Remove `return_url` from PaymentIntent creation call

### DIFF
--- a/web.rb
+++ b/web.rb
@@ -128,7 +128,6 @@ post '/create_intent' do
       :amount => params[:amount],
       :currency => params[:currency] || 'usd',
       :description => params[:description] || 'Example PaymentIntent charge',
-      :return_url => params[:return_url],
       :metadata => {
         :order_id => '5278735C-1F40-407D-933A-286E463E72D8',
       }.merge(params[:metadata] || {}),


### PR DESCRIPTION
PaymentIntents do not support providing the `return_url` at creation time anymore.
Instead, they're provided during the call to `confirm`, by the mobile SDK.