### PR TITLE
allowed_source_types has been renamed to payment_method_types

### DIFF
--- a/web.rb
+++ b/web.rb
@@ -124,7 +124,7 @@ end
 post '/create_intent' do
   begin
     intent = Stripe::PaymentIntent.create(
-      :allowed_source_types => ['card'],
+      :payment_method_types => ['card'],
       :amount => params[:amount],
       :currency => params[:currency] || 'usd',
       :description => params[:description] || 'Example PaymentIntent charge',


### PR DESCRIPTION
## Summary

While attempting to run the [Stripe Android](https://github.com/stripe/stripe-android) Example app, there was an error creating the payment intent. Viewing the request in the developer console revealed the ruby app is using the latest API version and the following error:

``` json
{
  "error": {
    "code": "parameter_unknown",
    "doc_url": "https://stripe.com/docs/error-codes/parameter-unknown",
    "message": "Received unknown parameter: allowed_source_types",
    "param": "allowed_source_types",
    "type": "invalid_request_error"
  }
}
```

Checking the API documents revealed that the `allowed_source_types` parameter was changed to `payment_method_types` with [API version 2019-02-11](https://stripe.com/docs/upgrades#2019-02-11).

## Testing

Ran the example android stripe app and was able to successfully create payment intents.