### PR TITLE
Attach test cards to created customers for testing convenience

### DIFF
--- a/web.rb
+++ b/web.rb
@@ -103,7 +103,7 @@ def authenticate!
         },
       )
       # Attach some test cards to the customer for testing convenience.
-      # See https://stripe.com/docs/payments/3d-secure#three-ds-cards
+      # See https://stripe.com/docs/testing#cards
       ['4000000000003220', '4242424242424242'].each { |number|
         paymentMethod = Stripe::PaymentMethod.create({
           type: 'card',

--- a/web.rb
+++ b/web.rb
@@ -102,6 +102,26 @@ def authenticate!
           :my_customer_id => '72F8C533-FCD5-47A6-A45B-3956CA8C792D',
         },
       )
+      # Attach some test cards to the customer for testing convenience.
+      # See https://stripe.com/docs/payments/3d-secure#three-ds-cards
+      ['4000000000003220', '4242424242424242'].each { |number|
+        paymentMethod = Stripe::PaymentMethod.create({
+          type: 'card',
+          card: {
+            number: number,
+            exp_month: 5,
+            exp_year: 2023,
+            cvc: '000',
+          },
+        })
+        Stripe::PaymentMethod.attach(
+          paymentMethod.id,
+          {
+            customer: @customer.id,
+          }
+        )
+        }
+
     rescue Stripe::InvalidRequestError
     end
     session[:customer_id] = @customer.id

--- a/web.rb
+++ b/web.rb
@@ -104,18 +104,9 @@ def authenticate!
       )
       # Attach some test cards to the customer for testing convenience.
       # See https://stripe.com/docs/testing#cards
-      ['4000000000003220', '4242424242424242'].each { |number|
-        paymentMethod = Stripe::PaymentMethod.create({
-          type: 'card',
-          card: {
-            number: number,
-            exp_month: 5,
-            exp_year: 2023,
-            cvc: '000',
-          },
-        })
+      ['pm_card_threeDSecure2Required', 'pm_card_visa'].each { |pm_id|
         Stripe::PaymentMethod.attach(
-          paymentMethod.id,
+          pm_id,
           {
             customer: @customer.id,
           }


### PR DESCRIPTION
The `authenticate` method creates a Customer; this PR attaches some test card PaymentMethods to it.

## Testing

Pointed the sample app to local instance:

![image](https://user-images.githubusercontent.com/47796191/58713645-de927d80-8377-11e9-8831-f1ecb369a600.png)
