### PR TITLE
Add customer ID as param for create_setup_intent

### DIFF
--- a/web.rb
+++ b/web.rb
@@ -152,6 +152,7 @@ post '/create_setup_intent' do
       payment_method: payload[:payment_method],
       return_url: payload[:return_url],
       confirm: payload[:payment_method] != nil,
+      customer: payload[:customer_id],
       use_stripe_sdk: payload[:payment_method] != nil ? true : nil,
     })
   rescue Stripe::StripeError => e


### PR DESCRIPTION
This allows for the endpoint to be used in conjunction with the standard SDK components that attach PaymentMethods directly to customers. 

**Motivation**
https://jira.corp.stripe.com/browse/MOBILE-131