### PR TITLE
Add support for passing payment_method_types param in payload

### DIFF
--- a/web.rb
+++ b/web.rb
@@ -55,9 +55,10 @@ post '/capture_payment' do
         payload[:amount],
         payload[:source],
         payload[:payment_method],
+        payload[:payment_method_types] || ['card'],
         payload[:customer_id] || @customer.id,
         payload[:metadata],
-        'usd',
+        payload[:currency] || 'usd',
         payload[:shipping],
         payload[:return_url],
       )
@@ -148,7 +149,7 @@ post '/create_setup_intent' do
   end
   begin
     setup_intent = Stripe::SetupIntent.create({
-      payment_method_types: ['card'],
+      payment_method_types: payload[:payment_method_types] || ['card'],
       payment_method: payload[:payment_method],
       return_url: payload[:return_url],
       confirm: payload[:payment_method] != nil,
@@ -183,6 +184,7 @@ post '/create_intent' do
         params[:amount],
         nil,
         nil,
+        params[:payment_method_types] || ['card'],
         nil,
         params[:metadata],
         params[:currency],
@@ -226,6 +228,7 @@ post '/stripe-webhook' do
         source.amount,
         source.id,
         nil,
+        ['card'],
         source.metadata["customer"],
         source.metadata,
         source.currency,
@@ -244,7 +247,7 @@ post '/stripe-webhook' do
   status 200
 end
 
-def create_payment_intent(amount, source_id, payment_method_id, customer_id = nil,
+def create_payment_intent(amount, source_id, payment_method_id, payment_method_types = ['card'], customer_id = nil,
                           metadata = {}, currency = 'usd', shipping = nil, return_url = nil, confirm = false)
   return Stripe::PaymentIntent.create(
     :amount => amount,
@@ -252,7 +255,7 @@ def create_payment_intent(amount, source_id, payment_method_id, customer_id = ni
     :customer => customer_id,
     :source => source_id,
     :payment_method => payment_method_id,
-    :payment_method_types => ['card'],
+    :payment_method_types => payment_method_types,
     :description => "Example PaymentIntent",
     :shipping => shipping,
     :return_url => return_url,
@@ -266,8 +269,9 @@ def create_payment_intent(amount, source_id, payment_method_id, customer_id = ni
   )
 end
 
-def create_and_capture_payment_intent(amount, source_id, payment_method_id, customer_id = nil,
-                                      metadata = {}, currency = 'usd', shipping = nil, return_url = nil)
-  return create_payment_intent(amount, source_id, payment_method_id, customer_id,
-                                          metadata, currency, shipping, return_url, true)
+def create_and_capture_payment_intent(amount, source_id, payment_method_id, payment_method_types = ['card'],
+                                      customer_id = nil, metadata = {}, currency = 'usd', shipping = nil,
+                                      return_url = nil)
+  return create_payment_intent(amount, source_id, payment_method_id, payment_method_types,
+                               customer_id, metadata, currency, shipping, return_url, true)
 end


### PR DESCRIPTION
This is necessary for supporting payment methods other than 'card'