### PR TITLE
Update automatically attached credit cards for 3DS2 testing

### DIFF
--- a/web.rb
+++ b/web.rb
@@ -110,9 +110,25 @@ def authenticate!
     else
       begin
         @customer = create_customer()
+
+        payment_methods = ['pm_card_threeDSecure2Required', 'pm_card_visa']
+
+        ['4000000000003220', '4000000000003238', '4000000000003246', '4000000000003253'].each { |cc_number|
+          pm = Stripe::PaymentMethod.create({
+            type: 'card',
+            card: {
+              number: cc_number,
+              exp_month: 8,
+              exp_year: 2022,
+              cvc: '123',
+            },
+          })
+          payment_methods.push pm.id
+        }
+
         # Attach some test cards to the customer for testing convenience.
         # See https://stripe.com/docs/testing#cards
-        ['pm_card_threeDSecure2Required', 'pm_card_visa'].each { |pm_id|
+        payment_methods.each { |pm_id|
           Stripe::PaymentMethod.attach(
             pm_id,
             {

--- a/web.rb
+++ b/web.rb
@@ -111,9 +111,9 @@ def authenticate!
       begin
         @customer = create_customer()
 
-        payment_methods = ['pm_card_threeDSecure2Required', 'pm_card_visa']
+        payment_methods = []
 
-        ['4000000000003220', '4000000000003238', '4000000000003246', '4000000000003253'].each { |cc_number|
+        ['4000000000003220', '4000000000003238', '4000000000003246', '4000000000003253', '4242424242424242'].each { |cc_number|
           pm = Stripe::PaymentMethod.create({
             type: 'card',
             card: {

--- a/web.rb
+++ b/web.rb
@@ -111,10 +111,11 @@ def authenticate!
       begin
         @customer = create_customer()
 
-        payment_methods = []
-
+        # Attach some test cards to the customer for testing convenience.
+        # See https://stripe.com/docs/payments/3d-secure#three-ds-cards 
+        # and https://stripe.com/docs/mobile/android/authentication#testing
         ['4000000000003220', '4000000000003238', '4000000000003246', '4000000000003253', '4242424242424242'].each { |cc_number|
-          pm = Stripe::PaymentMethod.create({
+          payment_method = Stripe::PaymentMethod.create({
             type: 'card',
             card: {
               number: cc_number,
@@ -123,14 +124,9 @@ def authenticate!
               cvc: '123',
             },
           })
-          payment_methods.push pm.id
-        }
 
-        # Attach some test cards to the customer for testing convenience.
-        # See https://stripe.com/docs/testing#cards
-        payment_methods.each { |pm_id|
           Stripe::PaymentMethod.attach(
-            pm_id,
+            payment_method.id,
             {
               customer: @customer.id,
             }


### PR DESCRIPTION
Automatically attach the test credit card numbers from https://stripe.com/docs/mobile/android/authentication#testing as well as `4242`.