### PR TITLE
Update to match docs

### DIFF
--- a/web.rb
+++ b/web.rb
@@ -60,7 +60,7 @@ def authenticate!
         # Attach some test cards to the customer for testing convenience.
         # See https://stripe.com/docs/payments/3d-secure#three-ds-cards 
         # and https://stripe.com/docs/mobile/android/authentication#testing
-        ['4000000000003220', '4000000000003238', '4000000000003246', '4000000000003253', '4242424242424242'].each { |cc_number|
+        ['4000000000003220', '4000000000003063', '4000000000003238', '4000000000003246', '4000000000003253', '4242424242424242'].each { |cc_number|
           payment_method = Stripe::PaymentMethod.create({
             type: 'card',
             card: {

--- a/web.rb
+++ b/web.rb
@@ -203,7 +203,7 @@ post '/create_payment_intent' do
 
   begin
     payment_intent = create_payment_intent(
-      amount: payload[:amount] || 1000, # Sending the amount from the client is a security hazard, this is for demo purposes only
+      amount: 1099,
       customer_id: payload[:customer_id] || @customer.id,
       metadata: payload[:metadata],
       currency: payload[:currency],

--- a/web.rb
+++ b/web.rb
@@ -193,15 +193,13 @@ post '/create_payment_intent' do
       payment_intent = Stripe::PaymentIntent.retrieve(payment_intent_id)
     else
       payment_intent = create_payment_intent(
-        params[:amount] || 100, # Sending the amount from the client is a security hazard, this is for demo purposes only
-        nil,
-        nil,
-        params[:payment_method_types] || ['card'],
-        nil,
-        params[:metadata],
-        params[:currency],
-        nil,
-        nil
+        amount: params[:amount] || 100, # Sending the amount from the client is a security hazard, this is for demo purposes only
+        source_id: nil,
+        payment_method_id: nil,
+        payment_method_types: params[:payment_method_types] || ['card'],
+        customer_id: params[:customer_id] || @customer.id,
+        metadata: params[:metadata],
+        currency: params[:currency],
       )
     end
   rescue Stripe::StripeError => e

--- a/web.rb
+++ b/web.rb
@@ -211,7 +211,7 @@ post '/create_payment_intent' do
   begin
     payment_intent = Stripe::PaymentIntent.create(
       :amount => 1099, # A real implementation would calculate the amount based on e.g. an order id
-      :currency => payload[:currency] || 'usd',
+      :currency => 'usd',
       :customer => payload[:customer_id] || @customer.id,
       :description => "Example PaymentIntent",
       :capture_method => ENV['CAPTURE_METHOD'] == "manual" ? "manual" : "automatic",
@@ -256,7 +256,7 @@ post '/confirm_payment_intent' do
       # Create and confirm the PaymentIntent
       payment_intent = Stripe::PaymentIntent.create(
         :amount => 1099, # A real implementation would calculate the amount based on e.g. an order id
-        :currency => payload[:currency] || 'usd',
+        :currency => 'usd',
         :customer => payload[:customer_id] || @customer.id,
         :source => payload[:source],
         :payment_method => payload[:payment_method_id],

--- a/web.rb
+++ b/web.rb
@@ -105,7 +105,6 @@ post '/create_setup_intent' do
   end
   begin
     setup_intent = Stripe::SetupIntent.create({
-      payment_method_types: payload[:payment_method_types] || ['card'],
       payment_method: payload[:payment_method],
       return_url: payload[:return_url],
       confirm: payload[:payment_method] != nil,
@@ -163,7 +162,7 @@ post '/stripe-webhook' do
   status 200
 end
 
-def create_payment_intent(amount:, source_id: nil, payment_method_id: nil, payment_method_types: nil, customer_id: nil,
+def create_payment_intent(amount:, source_id: nil, payment_method_id: nil, customer_id: nil,
                           metadata: {}, currency: nil, shipping: nil, return_url: nil, confirm: false)
   payment_intent_id = ENV['DEFAULT_PAYMENT_INTENT_ID']
   if payment_intent_id
@@ -176,7 +175,6 @@ def create_payment_intent(amount:, source_id: nil, payment_method_id: nil, payme
     :customer => customer_id,
     :source => source_id,
     :payment_method => payment_method_id,
-    :payment_method_types => payment_method_types || ['card'],
     :description => "Example PaymentIntent",
     :shipping => shipping,
     :return_url => return_url,
@@ -249,7 +247,6 @@ post '/manual_confirm_payment' do
         amount: 1099,
         source_id: params[:source],
         payment_method_id: params[:payment_method],
-        payment_method_types: params[:payment_method_types],
         customer_id: params[:customer_id] || @customer.id,
         metadata: params[:metadata],
         currency: params[:currency],

--- a/web.rb
+++ b/web.rb
@@ -187,6 +187,7 @@ end
 # Just like the `/capture_payment` endpoint, a real implementation would include controls
 # to prevent misuse
 post '/create_payment_intent' do
+  authenticate!
   begin
     payment_intent_id = ENV['DEFAULT_PAYMENT_INTENT_ID']
     if payment_intent_id

--- a/web.rb
+++ b/web.rb
@@ -253,7 +253,7 @@ end
 # https://stripe.com/docs/api/payment_intents/create
 # https://stripe.com/docs/api/payment_intents/confirm
 # A real implementation would include controls to prevent misuse
-post '/manual_confirm_payment' do
+post '/confirm_payment_intent' do
   payload = params
   if request.content_type.include? 'application/json' and params.empty?
     payload = Sinatra::IndifferentHash[JSON.parse(request.body.read)]

--- a/web.rb
+++ b/web.rb
@@ -225,7 +225,7 @@ post '/create_payment_intent' do
 
   begin
     payment_intent = create_payment_intent(
-      amount: 1099,
+      amount: 1099, # A real implementation would calculate the amount based on e.g. an order id
       source_id: params[:source],
       customer_id: payload[:customer_id] || @customer.id,
       metadata: payload[:metadata],
@@ -267,7 +267,7 @@ post '/manual_confirm_payment' do
       authenticate!
       # Create and confirm the PaymentIntent
       payment_intent = create_payment_intent(
-        amount: 1099,
+        amount: 1099, # A real implementation would calculate the amount based on e.g. an order id
         source_id: params[:source],
         payment_method_id: params[:payment_method],
         customer_id: params[:customer_id] || @customer.id,

--- a/web.rb
+++ b/web.rb
@@ -204,6 +204,7 @@ post '/create_payment_intent' do
   begin
     payment_intent = create_payment_intent(
       amount: 1099,
+      source_id: params[:source],
       customer_id: payload[:customer_id] || @customer.id,
       metadata: payload[:metadata],
       currency: payload[:currency],

--- a/web.rb
+++ b/web.rb
@@ -186,14 +186,14 @@ end
 # https://stripe.com/docs/api/payment_intents/create
 # Just like the `/capture_payment` endpoint, a real implementation would include controls
 # to prevent misuse
-post '/create_intent' do
+post '/create_payment_intent' do
   begin
     payment_intent_id = ENV['DEFAULT_PAYMENT_INTENT_ID']
     if payment_intent_id
       payment_intent = Stripe::PaymentIntent.retrieve(payment_intent_id)
     else
       payment_intent = create_payment_intent(
-        params[:amount],
+        params[:amount] || 100, # Sending the amount from the client is a security hazard, this is for demo purposes only
         nil,
         nil,
         params[:payment_method_types] || ['card'],


### PR DESCRIPTION
## Breaking changes

* Passing `amount` and `currency` is ignored, hardcoded on the backend instead. (https://jira.corp.stripe.com/browse/IOS-242) 

#### Automatic PI confirmation:
* Rename `create_intent` -> `create_payment_intent`

#### Manual PI confirmation: 
* Instead of `capture_payment`, call `confirm_payment_intent`.  Pass `payment_method_id` instead of `payment_method`.
* Instead of `confirm_payment`, call `confirm_payment_intent`.
* Instead of returning `secret`, if the PI status is...
  * `requires_action` -> returns `requires_action: true, secret: abc`
  * `requires_capture` or `succeeded` -> returns `success: true`
  * anything else -> 500

## Other changes 
* Fixed webhooks


## Testing
Using 3ds1, 3ds2, error cards:
* Custom Integration
  [x] Manual confirmation
  [x] Automatic confirmation
  [x] Setup Intent, SetupIntent Backend confirm
[x] Standard Integration

Tested webhooks for
* PI manual confirmation 
* Sofort