### PR TITLE
Force SetupIntent to use payment_method_types=['card']

### DIFF
--- a/web.rb
+++ b/web.rb
@@ -179,7 +179,7 @@ post '/create_setup_intent' do
       confirm: payload[:payment_method] != nil,
       customer: payload[:customer_id],
       use_stripe_sdk: payload[:payment_method] != nil ? true : nil,
-      payment_method_types: payment_methods_for_country(payload[:country]),
+      payment_method_types: ['card'],
     })
   rescue Stripe::StripeError => e
     status 402


### PR DESCRIPTION
At this time, SetupIntent only supports the card type